### PR TITLE
Check if the date range is already parsed

### DIFF
--- a/visavail.js
+++ b/visavail.js
@@ -450,24 +450,28 @@
 				
 				if(options.display_date_range && (options.display_date_range[0] || options.display_date_range[1])){
 					if(options.display_date_range[0]){
-						if (parseDateRegEx.test(options.display_date_range[0])) {
-							options.display_date_range[0] = parseDate(options.display_date_range[0]);
-						} else if (parseDateTimeRegEx.test(options.display_date_range[0])) {
-							options.display_date_range[0] = parseDateTime(options.display_date_range[0]);
-						} else {
-							throw new Error('Option of Display range Date/time format not recognized. Pick between \'YYYY-MM-DD\' or ' +
-								'\'YYYY-MM-DD HH:MM:SS\'.');
+						if (!(options.display_date_range[0] instanceof Date)) {
+							if (parseDateRegEx.test(options.display_date_range[0])) {
+								options.display_date_range[0] = parseDate(options.display_date_range[0]);
+							} else if (parseDateTimeRegEx.test(options.display_date_range[0])) {
+								options.display_date_range[0] = parseDateTime(options.display_date_range[0]);
+							} else {
+								throw new Error('Option of Display range Date/time format not recognized. Pick between \'YYYY-MM-DD\' or ' +
+									'\'YYYY-MM-DD HH:MM:SS\'.');
+							}
 						}
 						startDate = moment(options.display_date_range[0]);
 					}
 					if(options.display_date_range[1]){
-						if (parseDateRegEx.test(options.display_date_range[1])) {
-							options.display_date_range[1] = parseDate(options.display_date_range[1]);
-						} else if (parseDateTimeRegEx.test(options.display_date_range[1])) {
-							options.display_date_range[1] = parseDateTime(options.display_date_range[1]);
-						} else {
-							throw new Error('Option of Display range Date/time format not recognized. Pick between \'YYYY-MM-DD\' or ' +
-								'\'YYYY-MM-DD HH:MM:SS\'.');
+						if (!(options.display_date_range[1] instanceof Date)) {
+							if (parseDateRegEx.test(options.display_date_range[1])) {
+								options.display_date_range[1] = parseDate(options.display_date_range[1]);
+							} else if (parseDateTimeRegEx.test(options.display_date_range[1])) {
+								options.display_date_range[1] = parseDateTime(options.display_date_range[1]);
+							} else {
+								throw new Error('Option of Display range Date/time format not recognized. Pick between \'YYYY-MM-DD\' or ' +
+									'\'YYYY-MM-DD HH:MM:SS\'.');
+							}
 						}
 						endDate = moment(options.display_date_range[1]);
 					}


### PR DESCRIPTION
I've encountered an error when attempting to use `updateGraph`. The visavail tries to match the Date objects it parsed in the first `generate` call with the regexes. This PR adds a type check to prevent this.

Caveat: I was unable to generate the minified version due to my enviroment here.